### PR TITLE
Upgrade to Manifest Version 3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,32 @@
+{
+  "manifest_version": 3,
+  "name": "Browser Event Logger",
+  "version": "1.0.0",
+  "description": "A browser extension for logging events",
+  "permissions": [
+    "storage",
+    "activeTab"
+  ],
+  "action": {
+    "default_popup": "index.html",
+    "default_icon": {
+      "16": "assets/icon16.png",
+      "48": "assets/icon48.png",
+      "128": "assets/icon128.png"
+    }
+  },
+  "background": {
+    "service_worker": "src/background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content.js"]
+    }
+  ],
+  "icons": {
+    "16": "assets/icon16.png",
+    "48": "assets/icon48.png",
+    "128": "assets/icon128.png"
+  }
+}


### PR DESCRIPTION
# Upgrade to Manifest Version 3

This pull request introduces the upgrade to manifest version 3 for the Browser Event Logger project. The changes include the creation of a new manifest.json file with the necessary structure and fields required by the manifest version 3 specifications.

## Changes Made:
- Created a new manifest.json file in the project root directory
- Set the manifest_version to 3
- Added required fields for a Manifest V3 file, including:
  - name
  - version
  - description
  - permissions
  - action (replacing browser_action)
  - background (with service_worker)
  - content_scripts
  - icons

## Next Steps:
- Review the manifest.json file to ensure all necessary permissions and configurations are included
- Update any existing background scripts to use the service worker format
- Adjust content scripts and popup HTML/JS if needed to comply with Manifest V3 requirements

Please review these changes and provide any feedback or additional requirements for the manifest upgrade.

Link to Devin run: https://preview.devin.ai/devin/009f7f6a8f8246a98f9e1d679cfe965d
